### PR TITLE
Fix getWindowById returning wrong window

### DIFF
--- a/src/net/codeengine/windowmanagement/WindowManager.as
+++ b/src/net/codeengine/windowmanagement/WindowManager.as
@@ -1013,16 +1013,17 @@ package net.codeengine.windowmanagement
 		 *
 		 * @return An existing window object or null if no window matches the specified window id.
 		 */
-		public function getWindowById(forWindowId:String):IWindow
-		{
-			var window:IWindow=null;
-			for each (window in this.allMyWindows)
-			{
-				if (window.windowId == forWindowId)
-					break;
-			}
-			return window;
-		}
+               public function getWindowById(forWindowId:String):IWindow
+               {
+                       for each (var window:IWindow in this.allMyWindows)
+                       {
+                               if (window.windowId == forWindowId)
+                               {
+                                       return window;
+                               }
+                       }
+                       return null;
+               }
 
 		/**
 		 * Remove the specified sheet from the specified window.


### PR DESCRIPTION
## Summary
- bugfix: return `null` if a window ID is not found in `getWindowById`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e70460b748321ae26ed0ca196d1f7